### PR TITLE
Fix duplicate monitors on certificate pid

### DIFF
--- a/src/evel_people.erl
+++ b/src/evel_people.erl
@@ -121,7 +121,7 @@ handle_inquire_voters({ElectionId, From, VoterCount, DoMonitor}, State) ->
           fun hash_ring_node:get_key/1,
           hash_ring:collect_nodes(ElectionId, VoterCount, State#?STATE.people)),
     Listeners =
-        case DoMonitor of
+        case DoMonitor andalso not lists:member(From, State#?STATE.listeners) of
             false -> State#?STATE.listeners;
             true  ->
                 _ = monitor(process, From),


### PR DESCRIPTION
Every time we inquire voters we monitor (and add to the list of listeners on evel_people), without checking if it is already a listener. If you call elect on node boot, population changes and we call inquire voters with true on DoMonitor argument.

@lrascao can you also review this PR, thanks.